### PR TITLE
InsteonPLM: 2845-222 Add support to battery level and low battery watermark reading

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -470,6 +470,37 @@ public abstract class MessageHandler {
 			}
 		}
 	}
+	
+	public static class HiddenDoorSensorDataReplyHandler extends MessageHandler {
+		HiddenDoorSensorDataReplyHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			InsteonDevice dev = f.getDevice();
+			if (!msg.isExtended()) {
+				logger.trace("{} device {} ignoring non-extended msg {}", nm(), dev.getAddress(), msg);
+				return;
+			}
+			try {
+				int cmd2 = (int) (msg.getByte("command2") & 0xff);
+				switch (cmd2) {
+				case 0x00: // this is a product data response message
+					int batteryLevel = msg.getByte("userData4") & 0xff;
+					int batteryWatermark = msg.getByte("userData7") & 0xff;
+					logger.debug("{}: {} got light level: {}, battery level: {}",
+								nm(), dev.getAddress(), batteryWatermark, batteryLevel);
+					m_feature.publish(new DecimalType(batteryWatermark), StateChangeType.CHANGED, "field", "batteryWatermark_level");
+					m_feature.publish(new DecimalType(batteryLevel), StateChangeType.CHANGED, "field", "battery_level");
+					break;
+				default:
+					logger.warn("unknown cmd2 = {} in info reply message {}", cmd2, msg);
+					break;
+				}
+			} catch (FieldException e) {
+				logger.error("error parsing {}: ", msg, e);
+			}
+		}
+	}
 
 	public static class PowerMeterUpdateHandler extends MessageHandler {
 		PowerMeterUpdateHandler(DeviceFeature p) { super(p); }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -489,7 +489,7 @@ public abstract class MessageHandler {
 					int batteryWatermark = msg.getByte("userData7") & 0xff;
 					logger.debug("{}: {} got light level: {}, battery level: {}",
 								nm(), dev.getAddress(), batteryWatermark, batteryLevel);
-					m_feature.publish(new DecimalType(batteryWatermark), StateChangeType.CHANGED, "field", "batteryWatermark_level");
+					m_feature.publish(new DecimalType(batteryWatermark), StateChangeType.CHANGED, "field", "battery_watermark_level");
 					m_feature.publish(new DecimalType(batteryLevel), StateChangeType.CHANGED, "field", "battery_level");
 					break;
 				default:

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -175,6 +175,15 @@
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
+<feature name="HiddenDoorSensorData">
+	<message-dispatcher>SimpleDispatcher</message-dispatcher>
+	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x2e">MotionSensorDataReplyHandler</message-handler>
+	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
 <feature name="GenericContact">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -180,7 +180,7 @@
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
-	<message-handler cmd="0x2e">MotionSensorDataReplyHandler</message-handler>
+	<message-handler cmd="0x2e">HiddenDooorSensorDataReplyHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -133,7 +133,8 @@ Example entry:
  <device productKey="F00.00.03">
      <model>2845-222</model>
      <description>Hidden Door Sensor</description>
-     <feature name="contact">GenericContact</feature>
+     <feature name="contact">WirelessMotionSensorContact</feature>
+     <feature name="data">HiddenDoorSensorData</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 


### PR DESCRIPTION
Hi Bernd,

I add a handler for Hidden Door Sensor to extract battery level from a 0x2E message reply. I tested this with success on binding based on OpenHAB master branch (latest) and I was coming to ask you to review and notice that your insteonPLM branch is a little ahead with new very interesting features. So I did a quick change in my original patch (you can find original at my github on branch insteon-hidden-sensor) to match the new scheme. Please, verify if I did not make any mistake since I am not very familiar with this scheme and I could not test the code since my running openHab is 1.6.2 version. 

In time, I have a doubt. I changed the contact handler to same handler as Motion Sensor because I assumed that this handler causes the querying of the device (while using genericContact device was not queried when wake up from sleep). Since I had nothing to change on the contact handler from motion sensor I kept original name (WirelessMotionSensorContact) but if you think we shall keep the same handler I think the best approach is to rename this handler since it will cause confusion to someone digging the code for the first time (without historic knowledge of this implementation).

Please, let me know your impressions and I am at your disposal for tests and change this code to meet your requirements for integration. Meanwhile, I will submit a pull request with the solution from my other branch to openHab master. Do you have any objections? (I will put this question there and you can comment positively or negative)

Best regards,
Benito

PS: proof of this working on V1.6.2:

2015-02-12 00:02:37 DEBUG o.o.b.i.i.device.DeviceFeature[:210]- XX.XX.XX:GenericLastTime publishing: 2015-02-12T00:02:37
2015-02-12 00:02:38 DEBUG o.o.b.i.InsteonPLMActiveBinding[:511]- got msg: IN:Cmd:0x51|fromAddress:XX.XX.XX|toAddress:MM.MM.MM|messageFlags:0x1B=DIRECT:3:2|command1:0x2E|command2:0x00|userData1:0x01|userData2:0x01|userData3:0x21|userData4:0x55|userData5:0xFF|userData6:0x0C|userData7:0x40|userData8:0x00|userData9:0x00|userData10:0x00|userData11:0x00|userData12:0x00|userData13:0x00|userData14:0xD2|
2015-02-12 00:02:38 DEBUG o.o.b.i.i.d.MessageHandler[:227]- NoOpMsgHandler ignore msg 0x2E: IN:Cmd:0x51|fromAddress:XX.XX.XX|toAddress:MM.MM.MM|messageFlags:0x1B=DIRECT:3:2|command1:0x2E|command2:0x00|userData1:0x01|userData2:0x01|userData3:0x21|userData4:0x55|userData5:0xFF|userData6:0x0C|userData7:0x40|userData8:0x00|userData9:0x00|userData10:0x00|userData11:0x00|userData12:0x00|userData13:0x00|userData14:0xD2|
2015-02-12 00:02:38 DEBUG o.o.b.i.i.d.MessageHandler[:498]- XX.XX.XX got battery level 85
2015-02-12 00:02:38 DEBUG o.o.b.i.i.device.DeviceFeature[:210]- XX.XX.XX:HiddenDoorBatteryLevel publishing: 85
