### PR TITLE
Correcting misspelled device feature name I've introduced by mistake

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -180,7 +180,7 @@
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
-	<message-handler cmd="0x2e">HiddenDooorSensorDataReplyHandler</message-handler>
+	<message-handler cmd="0x2e">HiddenDoorSensorDataReplyHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>


### PR DESCRIPTION
Hi Bernd,

This intends to correct a misspelled feature I've introduced on my last contribution. As pointed out by Charles (https://groups.google.com/forum/#!category-topic/openhab/insteon/tVq1CmLYD-U), there was a spare 'o'  in "Door".

Sorry for this error.
